### PR TITLE
generate separate .jar file for the web classes

### DIFF
--- a/myschedule-web/pom.xml
+++ b/myschedule-web/pom.xml
@@ -73,6 +73,13 @@
 		<finalName>myschedule</finalName>
 		<plugins>
 			<plugin>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<attachClasses>true</attachClasses>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.tomcat.maven</groupId>
 				<artifactId>tomcat7-maven-plugin</artifactId>
 				<version>2.0</version>


### PR DESCRIPTION
This is for easier embedding of the GUI into any Servlet based application.
You just need to add 'myschedule:myschedule-web:3.2.1.1.0:classes' to your dependencies, and then add some entries in web.xml. There is no need to copy and/or modify myschedule-web.war

This should resolve the original question mentioned in #114 
